### PR TITLE
Use copy artifacts instead of clone workspace;

### DIFF
--- a/jenkins-automation.groovy
+++ b/jenkins-automation.groovy
@@ -15,11 +15,12 @@ job('template-base-js') {
   parameters {
     stringParam("WORKSPACE_BUILDER", "", "name of the workspace builder job from which to clone the workspace")
   }
-  scm {
-    cloneWorkspace('$WORKSPACE_BUILDER')
-  }
+  
   wrappers {
     nodejs('Node 0.12')
+  }
+  steps {
+    copyArtifacts('$WORKSPACE_BUILDER')
   }
 }
 
@@ -71,10 +72,8 @@ job('template-deploy') {
     choiceParam("INVENTORY_FILE", ["dev", "test", "prod"], "name of ansible inventory file to use for deployment")
     stringParam("WORKSPACE_BUILDER", "", "name of the workspace builder job from which to clone the workspace")
   }
-  scm {
-    cloneWorkspace('$WORKSPACE_BUILDER')
-  }
   steps {
+    copyArtifacts('$WORKSPACE_BUILDER')
     shell(
       '''
       # enable python virtualenv that has ansible already installed
@@ -98,7 +97,10 @@ job('template-workspace-builder-base') {
   }
 
   publishers {
-    publishCloneWorkspace('')
+    archiveArtifacts {
+      pattern('**')
+      defaultExcludes(false)
+    }
   }
 }
 


### PR DESCRIPTION
the clone workspace plugin was extremely inefficient and took
several minutes to clone a workspace.  Rewrote the same functionality
using the copy artifacts plugin to give us a significant
performance improvement.
