### PR TITLE
Add 'jobs' to build source sets 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,3 +27,11 @@ dependencies {
         exclude module: 'groovy-all'
     }
 }
+
+sourceSets {
+    main {
+        groovy {
+            srcDirs = ['src/main/groovy', 'jobs'  ]
+        }
+    }
+}

--- a/src/main/groovy/jenkins/automation/utils/BaseJobBuilder.groovy
+++ b/src/main/groovy/jenkins/automation/utils/BaseJobBuilder.groovy
@@ -33,6 +33,7 @@ class BaseJobBuilder {
                 numToKeep(10)
             }
             publishers{
+                allowBrokenBuildClaiming()
                 mailer emails.join(' ')  //TODO use extended email
             }
         }


### PR DESCRIPTION
This ensures we get compiling checking on example jobs.

To see it in action:

1) before merging, open up an example from `jobs`; make it syntactically invalid
2) build the project

result: no errors

Now, merge this change, do the same thing, and voila, errors, which is a good thing
