### PR TITLE
Modify flow builder

### DIFF
--- a/src/main/groovy/jenkins/automation/builders/FlowJobBuilder.groovy
+++ b/src/main/groovy/jenkins/automation/builders/FlowJobBuilder.groovy
@@ -17,6 +17,7 @@ class FlowJobBuilder {
     List<String> jobs
     String name
     String description
+    String jobFlow = null
 
     /**
      * @param DLS factory class,  provided by Jenkins when executed from build context
@@ -28,9 +29,14 @@ class FlowJobBuilder {
 
             String jobsToBuild =""
 
-            jobs.each {jobName->
-                jobsToBuild+= "build('${jobName}') \r\n"
+            if (jobFlow == null) {
+                jobs.each { jobName ->
+                    jobsToBuild += "build('${jobName}') \r\n"
+                }
+            } else {
+                jobsToBuild += jobFlow
             }
+
             buildFlow(jobsToBuild)
         }
     }

--- a/src/main/groovy/jenkins/automation/builders/FlowJobBuilder.groovy
+++ b/src/main/groovy/jenkins/automation/builders/FlowJobBuilder.groovy
@@ -9,6 +9,7 @@ import javaposse.jobdsl.dsl.Job
  * @param jobs  comma separated list of jobs to include in the build flow
  * @param name  job name
  * @param description  job description
+ * @param jobFlow optional parameter for jobs done in parallel
  * @see <a href="https://github.com/imuchnik/jenkins-automation/blob/gh-pages/docs/examples.md#flow-job-job-builder" target="_blank">Flow job builder example</a>
 
  *

--- a/src/main/groovy/jenkins/automation/builders/JsJobBuilder.groovy
+++ b/src/main/groovy/jenkins/automation/builders/JsJobBuilder.groovy
@@ -12,7 +12,11 @@ class JsJobBuilder {
     String pollScmSchedule = '@daily'
     String tasks
     String junitResults = '**/build/test-results/*.xml'
-    String artifacts = 'dist/'
+    def artifacts = {
+        pattern("dist/")
+        fingerprint()
+        defaultExcludes()
+    }
     List<String> emails
     Boolean use_versions
 
@@ -49,8 +53,10 @@ class JsJobBuilder {
 //                )
 //            }
 
-            publishers {
-                archiveArtifacts artifacts
+            if (artifacts) {
+                publishers {
+                    archiveArtifacts artifacts
+                }
             }
 
         }


### PR DESCRIPTION
-  Modify flow builder to take a string for jobs done in parallel
-  Make artifacts optional for JS job builder
