### PR TITLE
Add PeriodicJobBuilder

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -44,6 +44,7 @@ import jenkins.automation.builders.BddSecurityJobBuilder
 
 ```
 
+
 ## Base Job Builder
 
 
@@ -127,6 +128,34 @@ new JsJobBuilder(
 ).build(this)
 
 ```
+
+## Periodic Job Builder
+
+```
+import jenkins.automation.builders.PeriodicJobBuilder
+
+List developers = ['irina.muchnik@cfpb.gov', 'daniel.davis@cfpb.gov']
+String projectUrl = 'https://github.com/cfpb/bash-automation'
+String cronSchedule = 'H/10 * * * *'
+
+def periodicJob = new PeriodicJobBuilder(
+        name: 'periodic-job-name',
+        description: 'An example using a job builder for a periodic task.',
+        emails: developers,
+        cronSchedule: cronSchedule,
+        repo: projectUrl
+).build(this)
+
+periodicJob.with {
+  steps {
+    shell('''
+./execute_script_from_projectUrl_repo.sh
+''')
+  }
+}
+
+```
+
 ## Using MultiScm Utility 
 
 ```

--- a/src/main/groovy/jenkins/automation/builders/PeriodicJobBuilder.groovy
+++ b/src/main/groovy/jenkins/automation/builders/PeriodicJobBuilder.groovy
@@ -1,0 +1,59 @@
+package jenkins.automation.builders
+
+import javaposse.jobdsl.dsl.DslFactory
+import javaposse.jobdsl.dsl.Job
+import jenkins.automation.builders.BaseJobBuilder
+
+/**
+ * Run jobs with a set cron schedule
+ *
+ * @param name  job name
+ * @param description  job description
+ * @param emails  list of developers to get notifications
+ * @param cronSchedule  cron-style task schedule definition
+ * @param repo  github URL to clone into path (optional)
+ * @see <a href="https://github.com/imuchnik/jenkins-automation/blob/gh-pages/docs/examples.md#flow-job-job-builder" target="_blank">Flow job builder example</a>
+
+ *
+ */
+class PeriodicJobBuilder {
+
+    String name
+    String description
+    List<String> emails
+    String cronSchedule = 'H/15 * * * *'
+    String repo
+
+    Job build(DslFactory factory) {
+
+        def baseJob = new BaseJobBuilder(
+                name: this.name,
+                description: this.description,
+                emails: this.emails,
+        ).build(factory)
+
+        baseJob.with {
+            triggers {
+                if(cronSchedule) {
+                    cron(cronSchedule)
+                }
+            }
+        }
+
+        baseJob.with {
+            scm {
+                if(repo) {
+                    git {
+                        remote {
+                            url(repo)
+                        }
+                        branch('*/master')
+                    }
+                }
+            }
+        }
+
+        return baseJob
+    }
+}
+


### PR DESCRIPTION
PeriodicJobBuilder essentially creates cron jobs in Jenkins.
- cron syntax: `H/15 * * * *` runs every 15 minutes
- optional repo to clone if you need to run a script from a repo
