### PR TITLE
Add 'Unstable' as default email trigger; clean up extended email example

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -186,9 +186,9 @@ job('test') {
 ```
 import jenkins.automation.utils.CommonUtils
 
- job('example'){
+job('example'){
     CommonUtils.addDefaults(delegate)
-    }
+}
 ```
 
 ### Extended Email
@@ -196,27 +196,16 @@ import jenkins.automation.utils.CommonUtils
 ```
 import jenkins.automation.utils.CommonUtils
 
- job("example"){
-   CommonUtils.addExtendedEmail(delegate, 
-                 triggers = ["Failure", "Fixed"], 
-                 emails= 'someperson@email.com, someotherperson@email.com', 
-                 sendToDevelopers = false, 
-                 sendToRequester =true,
-                 includeCulprits = false, 
-                 sendToRecipientList = true) 
+job("example"){
+  CommonUtils.addExtendedEmail(delegate, 
+  emails = 'someperson@email.com, someotherperson@email.com') 
          
-    }
+}
    
    
-    //override accepts emails as a list. Compatable with builders
-     job('example'){
-       CommonUtils.addExtendedEmail(delegate, 
-                     emails= ['someperson@email.com', 'someotherperson@email.com'], 
-                     triggers = ["Failure", "Fixed"], 
-                     sendToDevelopers = false, 
-                     sendToRequester =true,
-                     includeCulprits = false, 
-                     sendToRecipientList = true) 
-             
-        }
+//override accepts emails as a list. Compatible with builders
+job('example'){
+  CommonUtils.addExtendedEmail(delegate, 
+  emails = ['someperson@email.com', 'someotherperson@email.com']) 
+}
 ```

--- a/src/main/groovy/jenkins/automation/utils/CommonUtils.groovy
+++ b/src/main/groovy/jenkins/automation/utils/CommonUtils.groovy
@@ -61,7 +61,7 @@ class CommonUtils {
  * @see <a href="https://github.com/cfpb/jenkins-automation/blob/gh-pages/docs/examples.md#common-utils" target="_blank">BDD job Example</a>
  */
 
-    static void addExtendedEmail(context, String emails, List<String> triggers = ["Failure", "Fixed"], sendToDevelopers = false, sendToRequester = true, includeCulprits = false, sendToRecipientList = true) {
+    static void addExtendedEmail(context, String emails, List<String> triggers = ["Failure", "Unstable", "Fixed"], sendToDevelopers = false, sendToRequester = true, includeCulprits = false, sendToRecipientList = true) {
         context.with {
             extendedEmail(emails) {
                 triggers.each {


### PR DESCRIPTION
If you want emails on failure, you quite likely also want emails on unstable, since both likely require action

For email examples, I removed the bits that were just duplicating the defaults.
