### PR TITLE
Update to make the EnvironmentUtils bits true for our Jenkinses

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -160,12 +160,12 @@ import jenkins.automation.utils.ScmUtils
 ```
 import jenkins.automation.utils.EnvironmentUtils
 
+//In our Jenkinses, we name this variable "JAC_ENVIRONMENT" with values of "dev", "stage", or "prod"
+//In your Jenkins, you can name the variable whatever you like; replace the variable you pass into 
+//EnvironmentUtils.getInstance(...) with your global variable name
 
-// ${ENVIRONMENT} is available directly from the scripts
-// It is a jenkins environment variable that is set directly in 
-//Jenkins system configuration.
-
-def env = EnvironmentUtils.getInstance("${ENVIRONMENT}")
+def env = EnvironmentUtils.getInstance("${JAC_ENVIRONMENT}")
+println "Environment is " + env.getEnv()
 
 if (env.isDev()){
     //set any other environment specific variables here
@@ -173,8 +173,7 @@ if (env.isDev()){
 
 job('test') {
     steps {
-        shell """echo $env
-      """
+        shell "echo $env"
     }
 }
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -160,15 +160,15 @@ import jenkins.automation.utils.ScmUtils
 ```
 import jenkins.automation.utils.EnvironmentUtils
 
-//In our Jenkinses, we name this variable "JAC_ENVIRONMENT" with values of "dev", "stage", or "prod"
-//In your Jenkins, you can name the variable whatever you like; replace the variable you pass into 
-//EnvironmentUtils.getInstance(...) with your global variable name
+// In our Jenkinses, we name this variable "JAC_ENVIRONMENT" with values of "DEV", "STAGE", or "PROD"
+// In your Jenkins, you can name the variable whatever you like; replace the variable you pass into 
+// EnvironmentUtils.getInstance(...) with your global variable name
 
 def env = EnvironmentUtils.getInstance("${JAC_ENVIRONMENT}")
 println "Environment is " + env.getEnv()
 
 if (env.isDev()){
-    //set any other environment specific variables here
+    // Do environment-specific things here
 }
 
 job('test') {
@@ -202,7 +202,7 @@ job("example"){
 }
    
    
-//override accepts emails as a list. Compatible with builders
+// override accepts emails as a list. Compatible with builders
 job('example'){
   CommonUtils.addExtendedEmail(delegate, 
   emails = ['someperson@email.com', 'someotherperson@email.com']) 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -173,7 +173,7 @@ if (env.isDev()){
 
 job('test') {
     steps {
-        shell "echo $env"
+        shell "echo ${env.getEnv()}"
     }
 }
 

--- a/example-jobs/envTestJob.groovy
+++ b/example-jobs/envTestJob.groovy
@@ -11,6 +11,6 @@ if(env.isDev()) {
 
 job('test') {
     steps {
-        shell "echo $env"
+        shell "echo ${env.getEnv()}"
     }
 }

--- a/example-jobs/envTestJob.groovy
+++ b/example-jobs/envTestJob.groovy
@@ -1,7 +1,7 @@
 import jenkins.automation.utils.EnvironmentUtils
 
-//in our Jenkinses, we have a global variable named "JAC_ENVIRONMENT",
-//with values of "dev", "stage", or "prod"
+// in our Jenkinses, we have a global variable named "JAC_ENVIRONMENT",
+// with values of "DEV", "STAGE", or "PROD"
 def env = EnvironmentUtils.getInstance("${JAC_ENVIRONMENT}")
 println "Environment is " + env.getEnv()
 

--- a/example-jobs/envTestJob.groovy
+++ b/example-jobs/envTestJob.groovy
@@ -1,15 +1,16 @@
 import jenkins.automation.utils.EnvironmentUtils
 
+//in our Jenkinses, we have a global variable named "JAC_ENVIRONMENT",
+//with values of "dev", "stage", or "prod"
+def env = EnvironmentUtils.getInstance("${JAC_ENVIRONMENT}")
+println "Environment is " + env.getEnv()
 
-def env=EnvironmentUtils.getInstance("${ENVIRONMENT}")
-
-if (env.isDev()){
+if(env.isDev()) {
     //do something
 }
 
 job('test') {
     steps {
-        shell """echo $env
-      """
+        shell "echo $env"
     }
 }


### PR DESCRIPTION
I am biased toward making our documentation and examples clear for our users. In addition, I think it's good to encourage a slightly less generic variable name than "ENVIRONMENT" for anyone using this library
