### PR TITLE
add a performance publisher util

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -233,3 +233,20 @@ new BaseJobBuilder(
     }
 }
 ```
+
+### Add a performance publisher block
+
+```
+import jenkins.automation.builders.BaseJobBuilder
+import jenkins.automation.utils.CommonUtils
+
+new BaseJobBuilder(
+        name: "sample-base-job-with-performance-publisher",
+        description: "A job with a performance publisher. It does not include the actual bits that run the load tests"
+).build(this).with {
+    steps {
+        shell("echo 'Run jmeter tests here'")
+    }
+    CommonUtils.addPerformancePublisher(delegate,failedThresholdPositive=10, failedThresholdNegative=10, unstableThresholdPositive=5, unstableThresholdNegative=5)
+}
+```

--- a/example-jobs/SampleBaseJobs.groovy
+++ b/example-jobs/SampleBaseJobs.groovy
@@ -39,6 +39,16 @@ new BaseJobBuilder(
     }
 }
 
+new BaseJobBuilder(
+        name: "sample-base-job-with-performance-publisher",
+        description: "A job with a performance publisher. It does not include the actual bits that run the load tests"
+).build(this).with {
+    steps {
+        shell("echo 'Run jmeter tests here'")
+    }
+    CommonUtils.addPerformancePublisher(delegate,failedThresholdPositive=10, failedThresholdNegative=10, unstableThresholdPositive=5, unstableThresholdNegative=5)
+}
+
 def repos = [
         [url: "https://github.com/cfpb/jenkins-automation@2.0"],
         [url: "https://github.com/cfpb/collab"]

--- a/src/main/groovy/jenkins/automation/utils/CommonUtils.groovy
+++ b/src/main/groovy/jenkins/automation/utils/CommonUtils.groovy
@@ -106,6 +106,39 @@ class CommonUtils {
     }
 
     /**
+     * Utility to add a performance publisher block, for use in performance tests
+     *
+     * @see <a href="https://github.com/cfpb/jenkins-automation/blob/gh-pages/docs/examples.md#common-utils" target="_blank">Common utils</a>
+     */
+
+    static void addPerformancePublisher(context, String reportPattern="**/results/*.jtl", String unstableResponseTimeThreshold="", int failedThresholdPositive, int failedThresholdNegative, int unstableThresholdPositive, int unstableThresholdNegative) {
+        context.with {
+            configure {
+                it / publishers << 'hudson.plugins.performance.PerformancePublisher' {
+                    errorFailedThreshold 2
+                    errorUnstableThreshold 1
+                    errorUnstableResponseTimeThreshold unstableResponseTimeThreshold
+                    relativeFailedThresholdPositive failedThresholdPositive
+                    relativeFailedThresholdNegative failedThresholdNegative
+                    relativeUnstableThresholdPositive unstableThresholdPositive
+                    relativeUnstableThresholdNegative unstableThresholdNegative
+                    modeRelativeThresholds false
+                    configType 'ART'
+                    modeOfThreshold true
+                    compareBuildPrevious true
+                    modePerformancePerTestCase true
+                    modeThroughput true
+                    parsers {
+                        'hudson.plugins.performance.JMeterParser' {
+                            glob reportPattern
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
      * Common string for creating and activating a python 2.7 virtualenv in a shell block
      *
      * @see <a href="https://github.com/cfpb/jenkins-automation/blob/gh-pages/docs/examples.md#common-utils" target="_blank">Common utils</a>


### PR DESCRIPTION
This is one I'm not quite sure about.

On one hand, it's quite useful. It exposes the common things that I think we want to tweak in our load test jobs (based on my experience writing our load test jobs).

On the other hand, it doesn't expose _all_ configurable items.

My thinking here is that it's a good enough, useful block for our load tests.

For jobs that require full control over the performance publisher, they're free to use this as a guide but directly configure it in their jobs.
