### PR TITLE
Move extended email to new format for DSL v1.43

### DIFF
--- a/src/main/groovy/jenkins/automation/utils/CommonUtils.groovy
+++ b/src/main/groovy/jenkins/automation/utils/CommonUtils.groovy
@@ -33,7 +33,7 @@ class CommonUtils {
     /** Utility function to add extended email
      *
      * @param List emails List of email string to make it seamlessly compatible with builders
-     * @param triggers List<String> triggers E.g Failure, Fixed etc...
+     * @param triggersList List<String> triggers E.g failure, fixed etc...
      * @param sendToDevelopers Default false,
      * @param sendToRequester Default true,
      * @param includeCulprits Default false,
@@ -42,14 +42,14 @@ class CommonUtils {
      * @see <a href="https://github.com/cfpb/jenkins-automation/blob/gh-pages/docs/examples.md#common-utils" target="_blank">Common utils</a>
      */
 
-    static void addExtendedEmail(context, List<String> emails, List<String> triggers = ["Failure", "Unstable", "Fixed"], sendToDevelopers = false,  sendToRequester = true, includeCulprits = false, sendToRecipientList = true) {
-        addExtendedEmail(context, emails.join(","), triggers, sendToDevelopers, sendToRequester, includeCulprits, sendToRecipientList)
+    static void addExtendedEmail(context, List<String> emails, List<String> triggerList = ["failure", "unstable", "fixed"], sendToDevelopers = false,  sendToRequester = true, includeCulprits = false, sendToRecipientList = true) {
+        addExtendedEmail(context, emails.join(","), triggerList, sendToDevelopers, sendToRequester, includeCulprits, sendToRecipientList)
     }
 
     /**
      * Utility function to add extended email
      * @param String emails Comma separated string of emails
-     * @param triggers List<String> triggers E.g Failure, Fixed etc...
+     * @param triggerList List<String> triggers E.g failure, fixed etc...
      * @param sendToDevelopers Default false,
      * @param sendToRequester Default true,
      * @param includeCulprits Default false,
@@ -58,12 +58,21 @@ class CommonUtils {
      * @see <a href="https://github.com/cfpb/jenkins-automation/blob/gh-pages/docs/examples.md#common-utils" target="_blank">Common utils</a>
      */
 
-    static void addExtendedEmail(context, String emails, List<String> triggers = ["Failure", "Unstable", "Fixed"], sendToDevelopers = false, sendToRequester = true, includeCulprits = false, sendToRecipientList = true) {
+    static void addExtendedEmail(context, String emails, List<String> triggerList = ["failure", "unstable", "fixed"], sendToDevelopers = false, sendToRequester = true, includeCulprits = false, sendToRecipientList = true) {
         context.with {
-            extendedEmail(emails) {
-                triggers.each {
-                    trigger(triggerName: it,
-                            sendToDevelopers: sendToDevelopers, sendToRequester: sendToRequester, includeCulprits: includeCulprits, sendToRecipientList: sendToRecipientList)
+            extendedEmail {
+                recipientList(emails)
+                triggers {
+                    triggerList.each {
+                        "${it}" {
+                            sendTo {
+                                if (sendToDevelopers) developers()
+                                if (sendToRequester) requester()
+                                if (includeCulprits) culprits()
+                                if (sendToRecipientList) recipientList()
+                            }
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
In Jenkins 1.43, the DSL format for extended email changed.

The CommonUtils.addExtendedEmail function was updated to reflect the new format.

Side Effects:
- the `triggers` parameter was renamed to `triggerList`
- the trigger values now need to be lowercase (e.g. 'failure' instead of 'Failure')

Change Description: https://github.com/jenkinsci/job-dsl-plugin/wiki/Migration#extended-email
API Docs: https://jenkinsci.github.io/job-dsl-plugin/#method/javaposse.jobdsl.dsl.helpers.publisher.PublisherContext.extendedEmail
