### PR TITLE
Update git to reflect DSL 1.44 changes

### DIFF
--- a/src/main/groovy/jenkins/automation/utils/ScmUtils.groovy
+++ b/src/main/groovy/jenkins/automation/utils/ScmUtils.groovy
@@ -36,12 +36,18 @@ class ScmUtils {
                     } else {
                         branch "master"
                     }
-                    relativeTargetDir(repo.sub_directory)
-                    shallowClone(repo.shallow && repo.shallow != null ? repo.shallow : true)
                     if (disable_submodule) {
                         configure { node ->
                             node / 'extensions' / 'hudson.plugins.git.extensions.impl.SubmoduleOption' {
                                 disableSubmodules disable_submodule
+                            }
+                        }
+                    }
+                    extensions {
+                        relativeTargetDirectory(repo.sub_directory)
+                        if (repo.shallow && repo.shallow != null) {
+                            cloneOptions {
+                                shallow()
                             }
                         }
                     }


### PR DESCRIPTION
Update relativeTargetDir and shallowClone functions to reflect the new format introduced in Jenkins DSL 1.44

[DSL migration documentation](https://github.com/jenkinsci/job-dsl-plugin/wiki/Migration#git)
[git DSL API documentation](https://jenkinsci.github.io/job-dsl-plugin/#method/javaposse.jobdsl.dsl.helpers.ScmContext.git)
