### PR TITLE
Add log parser rules for deprecation

### DIFF
--- a/log-parser-rules.txt
+++ b/log-parser-rules.txt
@@ -1,0 +1,1 @@
+warning /(?i)is deprecated/


### PR DESCRIPTION
Adding log-parser-rules.txt allows the Log Parser plugin to mark seed jobs as "unstable" if they contain deprecated DSL functionality.

For a list of recently deprecated functionality, refer to the [DSL migration page](https://github.com/jenkinsci/job-dsl-plugin/wiki/Migration)
