### PR TITLE
Add additional job config examples

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -2,7 +2,7 @@
 
 ## Base Job Builder
 
-```
+```groovy
 import jenkins.automation.builders.BaseJobBuilder
    
 new BaseJobBuilder(
@@ -14,7 +14,7 @@ new BaseJobBuilder(
 
 ## Checkmarx Security Job Builder
 
-```
+```groovy
 import jenkins.automation.builders.CheckmarxSecurityJobBuilder
 
 def groupId = "your-group-id"  
@@ -39,7 +39,7 @@ new CheckmarxSecurityJobBuilder(
 
 ## BDD Security Job Builder
 
-```
+```groovy
 import jenkins.automation.builders.BddSecurityJobBuilder
    
 def projectName ='sample-project'
@@ -55,7 +55,7 @@ new BddSecurityJobBuilder(
 
 ## Flow Job Builder
 
-```
+```groovy
 import jenkins.automation.builders.FlowJobBuilder
 
 new FlowJobBuilder(
@@ -88,7 +88,7 @@ new FlowJobBuilder(
 
 ## JS Build Job
 
-```
+```groovy
 import jenkins.automation.builders.JsJobBuilder
 
 String basePath = 'JsJobSamples'
@@ -114,7 +114,7 @@ new JsJobBuilder(
 
 # Salesforce Build Job
 
-```
+```groovy
 
 import jenkins.automation.builders.SalesforceAntJobBuilder
 
@@ -137,7 +137,7 @@ new SalesforceAntJobBuilder(
 =======
 
 
-```
+```groovy
 import jenkins.automation.builders.BaseJobBuilder
 import jenkins.automation.utils.ScmUtils
 
@@ -155,9 +155,11 @@ new BaseJobBuilder(
 }
 ```
 
-## Determining the environment
+## Customizing your job
 
-```
+### Determining the environment
+
+```groovy
 import jenkins.automation.utils.EnvironmentUtils
 
 // In our Jenkinses, we name this variable "JAC_ENVIRONMENT" with values of "DEV", "STAGE", or "PROD"
@@ -179,11 +181,43 @@ job('test') {
 
 ```
 
+### Running a job on a schedule
+
+```groovy
+job('example') {
+    triggers {
+       cron("H/15 * * * *")
+    }
+}
+```
+
+### Including a [Jenkins Custom Tool](https://wiki.jenkins-ci.org/display/JENKINS/Custom+Tools+Plugin)
+
+```groovy
+job('example') {
+    wrappers {
+       customTools(['jq'])
+    }
+}
+```
+
+### Including variables in a shell step
+
+```groovy
+var foo = 'bar';
+
+job('example') {
+    steps {
+       shell("my_command --my-arg ${foo}")
+    }
+}
+```
+
 ## Common Utils
 
 ### Defaults
 
-```
+```groovy
 import jenkins.automation.utils.CommonUtils
 
 job('example'){
@@ -193,7 +227,7 @@ job('example'){
 
 ### Extended Email
 
-```
+```groovy
 import jenkins.automation.utils.CommonUtils
 
 job("example"){
@@ -204,11 +238,16 @@ job("example"){
 job('example'){
     CommonUtils.addExtendedEmail(delegate, emails = ['foo@example.com', 'bar@example.com']) 
 }
+
+// Override default email triggers.
+job('example'){
+    CommonUtils.addExtendedEmail(delegate, emails, triggers=['statusChanged'])
+}
 ```
 
 ### Inject global passwords
 
-```
+```groovy
 import jenkins.automation.builders.BaseJobBuilder
 import jenkins.automation.utils.CommonUtils
 
@@ -222,7 +261,7 @@ new BaseJobBuilder(
 
 ### Add shell parsing rules
 
-```
+```groovy
 import jenkins.automation.builders.BaseJobBuilder
 import jenkins.automation.utils.CommonUtils
 
@@ -237,7 +276,7 @@ new BaseJobBuilder(
 
 ### Add virtualenv to a shell step
 
-```
+```groovy
 import jenkins.automation.builders.BaseJobBuilder
 import jenkins.automation.utils.CommonUtils
 
@@ -259,7 +298,7 @@ new BaseJobBuilder(
 
 ### Add a performance publisher block
 
-```
+```groovy
 import jenkins.automation.builders.BaseJobBuilder
 import jenkins.automation.utils.CommonUtils
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -204,11 +204,16 @@ job('example') {
 ### Including variables in a shell step
 
 ```groovy
-var foo = 'bar';
+var variable_from_this_script = 'foo';
 
 job('example') {
     steps {
-       shell("my_command --my-arg ${foo}")
+       shell("""
+          my_command \
+             --my-arg ${variable_from_this_script} \
+             --other-arg \${JENKINS_VARIABLE}
+         """.stripIndent()
+      )
     }
 }
 ```


### PR DESCRIPTION
Changed examples doc to use GFM Groovy [syntax highlighting](https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting).

Added a few useful examples:
- Run a job on a schedule
- Include a custom tool managed by the [Custom Tool Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Custom+Tools+Plugin)
- Include job variables in a shell step
- Change default email notification triggers
