### PR TITLE
Fix presendscript bug

### DIFF
--- a/src/main/groovy/jenkins/automation/utils/CommonUtils.groovy
+++ b/src/main/groovy/jenkins/automation/utils/CommonUtils.groovy
@@ -64,7 +64,7 @@ class CommonUtils {
         context.with {
             extendedEmail {
                 recipientList(emails)
-                preSendScript(preSendScript)
+                delegate.preSendScript(preSendScript)
                 triggers {
                     triggerList.each {
                         "${it}" {


### PR DESCRIPTION
`preSendScript(preSendScript)` errors because Groovy thinks the first instance of `preSendScript` is the variable.

```
ERROR: (CommonUtils.groovy, line 67) No signature of method: java.lang.String.call() is applicable for argument types: (java.lang.String) values: [$DEFAULT_PRESEND_SCRIPT]
Possible solutions: wait(), any(), wait(long), split(java.lang.String), take(int), each(groovy.lang.Closure)
```

There are two solutions:

1) Change the name of the variable to prevent a conflict

```
preSendScript(preSendScriptValue)
```

2) Use `delegate` to force the function name to work properly

```
delegate.preSendScript(preSendScript)
```

Since I don't like making variable names more complex, I chose option 2.