### PR TITLE
Updating to latest jobs-dsl-core plugin v1.57

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     compile "org.yaml:snakeyaml:1.10"
     compile 'org.codehaus.groovy:groovy-all:2.4.4'
     testCompile group: 'junit', name: 'junit', version: '4.11'
-    compile 'org.jenkins-ci.plugins:job-dsl-core:1.48'
+    compile 'org.jenkins-ci.plugins:job-dsl-core:1.57'
     testCompile('org.spockframework:spock-core:0.7-groovy-2.0') {
         exclude module: 'groovy-all'
     }

--- a/src/main/groovy/jenkins/automation/rest/RestApiJobManagement.groovy
+++ b/src/main/groovy/jenkins/automation/rest/RestApiJobManagement.groovy
@@ -10,6 +10,7 @@ import org.apache.http.entity.ContentType
 class RestApiJobManagement extends MockJobManagement {
 
     final RESTClient restClient
+    private boolean crumbHeaderSet = false
 
     RestApiJobManagement(String baseUrl) {
         if (!baseUrl.endsWith("/")) {
@@ -20,6 +21,7 @@ class RestApiJobManagement extends MockJobManagement {
     }
 
     void setCredentials(String username, String password) {
+        crumbHeaderSet = false
         restClient.headers['Authorization'] = 'Basic ' + "$username:$password".bytes.encodeBase64()
     }
 
@@ -88,6 +90,7 @@ class RestApiJobManagement extends MockJobManagement {
             path = isView ? 'createView' : 'createItem'
         }
 
+        setCrumbHeader()
         HttpResponseDecorator resp = restClient.post(
             path: path,
             body: xml,
@@ -99,6 +102,7 @@ class RestApiJobManagement extends MockJobManagement {
     }
 
     private boolean update(String name, String xml, boolean isView) {
+        setCrumbHeader()
         HttpResponseDecorator resp = restClient.post(
             path: getPath(name, isView) + '/config.xml',
             body: xml,
@@ -109,8 +113,9 @@ class RestApiJobManagement extends MockJobManagement {
     }
 
     private String fetchExistingXml(String name, boolean isView) {
+        setCrumbHeader()
         HttpResponseDecorator resp = restClient.get(
-            contentType: ContentType.DEFAULT_TEXT,
+            contentType: ContentType.TEXT,
             path: getPath(name, isView) + '/config.xml',
             headers: [Accept: 'application/xml'],
         )
@@ -118,6 +123,20 @@ class RestApiJobManagement extends MockJobManagement {
     }
 
     private static String getPath(String name, boolean isView) {
+        if (name.startsWith('/')) {
+            return '/' + getPath(name[1..-1], isView)
+        }
         isView ? "view/$name" : "job/${name.replaceAll('/', '/job/')}"
+    }
+
+    private setCrumbHeader() {
+        if (crumbHeaderSet)
+            return
+
+        HttpResponseDecorator resp = restClient.get(path: 'crumbIssuer/api/xml')
+        if (resp.status == 200) {
+            restClient.headers[resp.data.crumbRequestField] = resp.data.crumb
+        }
+        crumbHeaderSet = true
     }
 }

--- a/src/main/groovy/jenkins/automation/rest/RestApiJobManagement.groovy
+++ b/src/main/groovy/jenkins/automation/rest/RestApiJobManagement.groovy
@@ -115,7 +115,7 @@ class RestApiJobManagement extends MockJobManagement {
     private String fetchExistingXml(String name, boolean isView) {
         setCrumbHeader()
         HttpResponseDecorator resp = restClient.get(
-            contentType: ContentType.TEXT,
+            contentType: ContentType.DEFAULT_TEXT,
             path: getPath(name, isView) + '/config.xml',
             headers: [Accept: 'application/xml'],
         )

--- a/src/main/groovy/jenkins/automation/rest/RestApiScriptRunner.groovy
+++ b/src/main/groovy/jenkins/automation/rest/RestApiScriptRunner.groovy
@@ -3,6 +3,7 @@
 package jenkins.automation.rest
 
 import javaposse.jobdsl.dsl.DslScriptLoader
+import javaposse.jobdsl.dsl.ScriptRequest
 
 String pattern = System.getProperty('pattern')
 String baseUrl = System.getProperty('baseUrl')
@@ -28,5 +29,5 @@ params['JAC_HOST'] = System.getProperty('JAC_HOST') ?: 'aws'
 new FileNameFinder().getFileNames('.', pattern).each { String fileName ->
     println "\nprocessing file: $fileName"
     File file = new File(fileName)
-    DslScriptLoader.runDslEngine(file.text, jm)
+    new DslScriptLoader(jm).runScript(file.text)
 }

--- a/src/test/groovy/my_job_test.groovy
+++ b/src/test/groovy/my_job_test.groovy
@@ -14,7 +14,7 @@ class my_job_test extends Specification {
 
         when:
         ScriptRequest scriptRequest = new ScriptRequest(null, testjob, new File('.').toURI().toURL())
-        DslScriptLoader.runDslEngine(scriptRequest, jm)
+        new DslScriptLoader(jm).runScripts([scriptRequest])
         def result = jm.savedConfigs.collect { [name: it.key, xml: it.value] }
 
 


### PR DESCRIPTION
In the latest release the runDslEngine() method was deprecated and removed. This
commit makes the required API changes.