### PR TITLE
Copy `baseUrl` into the JENKINS_URL environment variable for the REST runner

### DIFF
--- a/src/main/groovy/jenkins/automation/rest/RestApiScriptRunner.groovy
+++ b/src/main/groovy/jenkins/automation/rest/RestApiScriptRunner.groovy
@@ -24,6 +24,8 @@ if (username && password) {
 params = jm.getParameters()
 params['JAC_ENVIRONMENT'] = System.getProperty('JAC_ENVIRONMENT') ?: 'dev'
 params['JAC_HOST'] = System.getProperty('JAC_HOST') ?: 'aws'
+params['JENKINS_URL'] = baseUrl
+
 
 new FileNameFinder().getFileNames('.', pattern).each { String fileName ->
     println "\nprocessing file: $fileName"


### PR DESCRIPTION
We use the JENKINS_URL environment variable in several jobs.
When seed jobs run in the Jenkins runtime, Jenkins automatically
supplies this variable. However, when creating jobs using the REST
runner, the variable does not exist. This change ensures that
environment variable is available by setting it to the required
`baseUrl` parameter