### PR TITLE
DEV-2470 - bugfix: per-job folder exclusion stopped working in Checkmarx jobs

### DIFF
--- a/src/main/groovy/jenkins/automation/builders/CheckmarxSecurityJobBuilder.groovy
+++ b/src/main/groovy/jenkins/automation/builders/CheckmarxSecurityJobBuilder.groovy
@@ -88,6 +88,7 @@ class CheckmarxSecurityJobBuilder {
                     'presetSpecified'(presetSpecified)
                     'excludeFolders'(excludeFolders)
                     'filterPattern'(filterPattern)
+                    'exclusionsSetting'('job')
                     'incremental' (incremental)
                     'fullScansScheduled'(false)
                     'fullScanCycle'(fullScanCycle)


### PR DESCRIPTION
After upgrading the Checkmarx plugin to version 8.5.0 -- or, at least, we noticed this problem after the upgrade, and it may be a coincidence -- the per-job folder exclusion stopped working, and jobs defaulted to the global exclusion settings. This restores the expected behavior.