### PR TITLE
Move dependency downloader to importable init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,26 @@ If the `emails` property is set on a job, the job automatically gets configured 
 - http://wiki.jenkins-ci.org/display/JENKINS/Multiple+SCMs+Plugin
 - http://wiki.jenkins-ci.org/display/JENKINS/NodeJS+Plugin
 - http://wiki.jenkins-ci.org/display/JENKINS/Clone+Workspace+SCM+Plugin
+
+
+### Gradle init scripts
+
+Within the path 
+
+```
+gradle/init.d/init.gradle
+```
+
+There is a file that contains tasks that may be imported into other 
+gradle builds by using the additional flag `-I` during normal gradle
+execution. Currently this file contains a task designed to copy the
+jar files of all dependencies of a project into a directory `jac_dependencies`.
+This tool may be useful when integrating with tools like
+[OWASP](https://www.owasp.org/index.php/OWASP_Dependency_Check)
+
+
+Common execution might be
+
+```
+./gradlew -I gradle/init.d/init.gradle copyDeps
+```

--- a/build.gradle
+++ b/build.gradle
@@ -61,12 +61,3 @@ groovydoc {
     source = files('src/main/groovy')
     destinationDir = file('.')
 }
-
-task copyDependencies(type: Copy) {
-   def osa_dir = new File('osa_dependencies')
-   if ( !osa_dir.exists() ) {
-      osa_dir.mkdirs()
-   }
-   from configurations.compile
-   into 'osa_dependencies'
-}

--- a/gradle/init.d/init.gradle
+++ b/gradle/init.d/init.gradle
@@ -1,0 +1,18 @@
+def copyConfigs = {
+      def osa_dir = new File('osa_dependencies')
+      if ( !osa_dir.exists() ) {
+          osa_dir.mkdirs()
+      }
+      from project.configurations.compile
+      into 'jac_dependencies'
+}
+
+allprojects { project ->
+    afterEvaluate {
+        project.tasks.create(
+            name: 'copyDeps',
+            type: Copy,
+            copyConfigs,
+        )
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,1 @@
 rootProject.name = 'jenkins-automation'
-


### PR DESCRIPTION
Adding this file allows a user to incorporate this function across gradle builds. Gradle can use this file when passing the `-I` flag.