### PR TITLE
DEV-2600 Update Sauce Connect builder and add example

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -259,6 +259,22 @@ new SalesforceAntJobBuilder(
 
 ```
 
+## Sauce On Demand job
+```groovy
+import jenkins.automation.builders.SauceConnectJobBuilder
+
+def projectName ='foo'
+new SauceConnectJobBuilder(
+        name: "example-browser-test",
+        description: "Sample Sauce on Demand job",
+        emails: ['email1@server1.com', 'email2@server2.com'],
+        sauceCredentialId: '1234',
+        // Note that when using Gradle build sauceCredentialId does not get populated.
+        // However, sauceCredentialId is correctly populated when built inside a Jenkins environment
+        additionalOptions: "-v"
+).build(this);
+```
+
 ## Using MultiScm Utility
 
 

--- a/src/main/groovy/jenkins/automation/builders/SauceConnectJobBuilder.groovy
+++ b/src/main/groovy/jenkins/automation/builders/SauceConnectJobBuilder.groovy
@@ -10,8 +10,9 @@ import javaposse.jobdsl.dsl.Job
  *
  * @param name job name
  * @param description job description
- * @param webDriverBrowser browser to use with Sauce Connect
- * @param sauceCredentialId SauceCredential to use for the sauce plugin
+ * @param webDriverBrowser (Optional) browser to use with Sauce Connect
+ * @param sauceCredentialId SauceCredential to use for the sauce plugin. Note that when using Gradle build this parameter does not get populated.
+ * However, this parameter is correctly populated when built inside a Jenkins environment.
  * @param additionalOptions (Optional) additional option to use e.g '-v'
  *
  */


### PR DESCRIPTION
We recently discovered that `sauceCredentialId` is not populated when the job is created using Gradle build. However, we do not see this issue when the job is created via the seed job inside Jenkins.
It seems that when we use Gradle build the code does not fall inside this conditional block: https://github.com/jenkinsci/job-dsl-plugin/blob/master/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/helpers/wrapper/WrapperContext.groovy#L650-L652

The job-dsl uses `jobManagement.isMinimumPluginVersionInstalled` to determine if the version of the Sauce On Demand Jenkins plugin is `1.148` or higher. This does not seem to be available via Gradle build.
