### PR TITLE
Update job-dsl dependency to latest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     compile "org.yaml:snakeyaml:1.10"
     compile 'org.codehaus.groovy:groovy-all:2.4.11'
     testCompile group: 'junit', name: 'junit', version: '4.11'
-    compile 'org.jenkins-ci.plugins:job-dsl-core:1.57'
+    compile 'org.jenkins-ci.plugins:job-dsl-core:1.74'
     testCompile('org.spockframework:spock-core:0.7-groovy-2.0') {
         exclude module: 'groovy-all'
     }


### PR DESCRIPTION
We're now running the latest job-dsl-plugin on our Jenkins servers. This
gets our automation helpers up to that version