### PR TITLE
APPOPS-425 Add id parameter to multibranch pipeline builder

### DIFF
--- a/src/main/groovy/jenkins/automation/builders/MultibranchPipelineJobBuilder.groovy
+++ b/src/main/groovy/jenkins/automation/builders/MultibranchPipelineJobBuilder.groovy
@@ -63,12 +63,14 @@ class MultibranchPipelineJobBuilder {
                 switch (branchSource) {
                     case BranchSourceType.GIT:
                         git {
+                            id(name)
                             remote(gitRemote)
                             credentialsId(gitCredentials)
                         }
                         break
                     case BranchSourceType.GITHUB:
                         github {
+                            id(name)
                             scanCredentialsId(gitCredentials)
                             repoOwner(ghOwner)
                             repository(ghRepo)


### PR DESCRIPTION
- Add `id` parameter to branchSources. This is required parameter in job-dsl plugin 1.76

The `id parameter` is set to correspond to the job name, in order to keep this parameter constant and unique within the Jenkins instance