### PR TITLE
Fixing typo in BaseJobBuilder.groovy

### DIFF
--- a/src/main/groovy/jenkins/automation/builders/BaseJobBuilder.groovy
+++ b/src/main/groovy/jenkins/automation/builders/BaseJobBuilder.groovy
@@ -38,7 +38,7 @@ class BaseJobBuilder {
                     publishers {
                         CommonUtils.addExtendedEmail(
                             delegate,
-                            emails: emails
+                            emails: emails,
                             attachBuildLog: attachBuildLog
                         )
                     }


### PR DESCRIPTION
Fixes bug in 823ce1c2d082d3899f332f1bd50b49eeb09c0f64.